### PR TITLE
fix: example-cli metadata and dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -177,3 +177,4 @@ docs/
 template-bun-executable
 /.releaserc
 functional_tests/features/support/__pycache__/pexpect_wrapper.cpython-311.pyc
+example-cli

--- a/bun.lock
+++ b/bun.lock
@@ -15,7 +15,7 @@
     },
   },
   "packages": {
-    "@flowscripter/dynamic-cli-framework": ["@flowscripter/dynamic-cli-framework@1.0.7", "", { "dependencies": { "emphasize": "^7.0.0", "fastest-levenshtein": "^1.0.16", "figlet": "^1.8.0", "highlight.js": "^11.11.1", "supports-color": "^10.0.0", "ts-log": "^2.2.7" }, "peerDependencies": { "typescript": "^5.8.2" } }, "sha512-b+aKuu1kqDkAzBp6XKNoTaZIF22eDCplBag5iXHC+uA7upzMdaBLdLsPYYLJ64v2elj+bfZhliZc4gwJcgZiAQ=="],
+    "@flowscripter/dynamic-cli-framework": ["@flowscripter/dynamic-cli-framework@1.0.8", "", { "dependencies": { "emphasize": "^7.0.0", "fastest-levenshtein": "^1.0.16", "figlet": "^1.8.0", "highlight.js": "^11.11.1", "supports-color": "^10.0.0", "ts-log": "^2.2.7" }, "peerDependencies": { "typescript": "^5.8.2" } }, "sha512-dyf12LQFHHO6G02otbkb7M1JaO930Xt0ORTFrhPlGsbMeF0sInnT4QOk029aULROxaGYlf96RMVfBZNmwYInoQ=="],
 
     "@types/bun": ["@types/bun@1.2.5", "", { "dependencies": { "bun-types": "1.2.5" } }, "sha512-w2OZTzrZTVtbnJew1pdFmgV99H0/L+Pvw+z1P67HaR18MHOzYnTYOi6qzErhK8HyT+DB782ADVPPE92Xu2/Opg=="],
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,18 @@
 {
   "name": "@flowscripter/example-cli",
+  "description": "Simple example CLI using https://github.com/flowscripter/dynamic-cli-framework",
+  "repository": "@flowscripter/example-cli",
+  "license": "MIT",
+  "keywords": [
+    "bun",
+    "example",
+    "plugin",
+    "framework",
+    "dynamic",
+    "import",
+    "executable",
+    "cli"
+  ],
   "module": "index.ts",
   "type": "module",
   "version": "1.0.1",
@@ -13,6 +26,6 @@
     "typescript": "^5.8.2"
   },
   "dependencies": {
-    "@flowscripter/dynamic-cli-framework": "^1.0.7"
+    "@flowscripter/dynamic-cli-framework": "^1.0.8"
   }
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -16,7 +16,7 @@ export async function cli(): Promise<void> {
   await launchMultiCommandCLI(
     [command1, command2],
     "Simple example CLI using dynamic-cli-framework.",
-    `example-cli`, // alternatively, name can be derived from executable name if this is not defined
+    "example-cli", // alternatively, name can be derived from executable name if this is not defined
     packageJson.version,
     false, // simple example, so disable env vars support for configuration defaults
     false, // simple example, so disable configuration support


### PR DESCRIPTION
Enhance the package.json for example-cli with a description, keywords, and repository information. Update the dynamic-cli-framework dependency to version 1.0.8 and ensure the example-cli name is correctly referenced in the code.