### PR TITLE
feat: enable UpgradeService and add upgrade functional test

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,7 @@
       "name": "@flowscripter/example-cli",
       "dependencies": {
         "@flowscripter/dynamic-cli-framework": "2.3.1",
+        "@flowscripter/dynamic-cli-framework-api": "^1.2.0",
         "@flowscripter/dynamic-plugin-framework": "1.11.1",
       },
       "devDependencies": {

--- a/functional_tests/features/upgrade.feature
+++ b/functional_tests/features/upgrade.feature
@@ -1,0 +1,6 @@
+Feature: Upgrade
+
+  Scenario: Running upgrade reports already up to date
+    When the executable is launched with "upgrade"
+    Then the executable should complete with exit code 0
+    And the executable should have output "example-cli is already up to date"

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "dependencies": {
     "@flowscripter/dynamic-cli-framework": "2.3.1",
+    "@flowscripter/dynamic-cli-framework-api": "^1.2.0",
     "@flowscripter/dynamic-plugin-framework": "1.11.1"
   },
   "devDependencies": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,6 +6,7 @@ import {
   SyntaxHighlighterServiceProvider,
   TreePrinterServiceProvider,
 } from "@flowscripter/dynamic-cli-framework";
+import { SupportedArch, SupportedOs } from "@flowscripter/dynamic-cli-framework-api";
 import {
   NpmPluginManager,
   NpmPluginRepository,
@@ -50,6 +51,32 @@ export async function cli(): Promise<void> {
       completionServiceEnabled: true,
       imagePrinterServiceEnabled: true,
       spawnServiceEnabled: true,
+      upgradeServiceEnabled: true,
+      upgradeLocationsConfig: {
+        supportedPlatforms: [
+          { os: SupportedOs.LINUX, arch: SupportedArch.X64 },
+          { os: SupportedOs.LINUX, arch: SupportedArch.ARM64 },
+          { os: SupportedOs.MACOS, arch: SupportedArch.X64 },
+          { os: SupportedOs.MACOS, arch: SupportedArch.ARM64 },
+          { os: SupportedOs.WINDOWS, arch: SupportedArch.X64 },
+        ],
+        githubRelease: {
+          owner: "flowscripter",
+          repo: "example-cli",
+          assetPattern: "example-cli_{os}_{arch}.zip",
+        },
+        linuxScript: {
+          scriptUrl:
+            "https://raw.githubusercontent.com/flowscripter/example-cli/main/script/install.sh",
+        },
+        homebrew: {
+          tap: "flowscripter/tap",
+          formula: "example-cli",
+        },
+        winget: {
+          packageId: "Flowscripter.example-cli",
+        },
+      },
     },
   );
 }


### PR DESCRIPTION
## Summary
- Enable `upgradeServiceEnabled` in `src/cli.ts` and populate `upgradeLocationsConfig` (githubRelease, linuxScript, homebrew, winget) using the release channels already documented in README/`script/install.sh`
- Add `@flowscripter/dynamic-cli-framework-api` as a direct dependency (needed for `SupportedOs`/`SupportedArch`, which the framework's public index doesn't re-export)
- Add a functional test scenario asserting the `upgrade` subcommand reports `"example-cli is already up to date"`, since CICD always builds and tests the just-released version

## Test plan
- [x] `bun install`, `bunx tsc --noEmit`, `bunx oxlint`, `bun test` all pass
- [x] Verified `upgrade` subcommand behaviour manually: correctly detects an update is available when the built version trails the latest GitHub release, and reports "already up to date" when versions match
- [x] Ran the new `upgrade.feature` functional test against a locally built binary with a version matching the latest release tag — passes

https://claude.ai/code/session_01MFgq62zjHr1T1L2EdMkPa9