### PR TITLE
DO NOT MERGE: diagnose Windows CI plugin:add hang

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -51,7 +51,7 @@ export async function cli(): Promise<void> {
       completionServiceEnabled: true,
       imagePrinterServiceEnabled: true,
       spawnServiceEnabled: true,
-      upgradeServiceEnabled: true,
+      upgradeServiceEnabled: false,
       upgradeLocationsConfig: {
         supportedPlatforms: [
           { os: SupportedOs.LINUX, arch: SupportedArch.X64 },


### PR DESCRIPTION
Diagnostic PR only, not for merge. Temporarily sets upgradeServiceEnabled to
false to test whether the auto-upgrade-on-startup prompt (added in #77) is
causing the "Install example-cli-plugin" functional test scenario to hang on
windows-latest test-executable jobs. Will close once we have a result.