### PR TITLE
chore: bump dynamic-cli-framework to 2.3.3

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "@flowscripter/example-cli",
       "dependencies": {
-        "@flowscripter/dynamic-cli-framework": "2.3.2",
+        "@flowscripter/dynamic-cli-framework": "2.3.3",
         "@flowscripter/dynamic-cli-framework-api": "^1.2.0",
         "@flowscripter/dynamic-plugin-framework": "1.11.1",
       },
@@ -21,7 +21,7 @@
     },
   },
   "packages": {
-    "@flowscripter/dynamic-cli-framework": ["@flowscripter/dynamic-cli-framework@2.3.2", "", { "dependencies": { "@flowscripter/dynamic-cli-framework-api": "^1.2.0", "@flowscripter/dynamic-plugin-framework": "1.11.1", "emphasize": "^7.0.0", "fastest-levenshtein": "^1.0.16", "figlet": "^1.11.0", "highlight.js": "^11.11.1", "prettier": "^3.9.4", "semver": "^7.7.3", "supports-color": "^10.2.2", "supports-terminal-graphics": "^0.1.0" }, "peerDependencies": { "typescript": "^6.0.3" } }, "sha512-AC7ad5pAf9EMLCrWiWw269SvZAaG/LO4f487Swyuvv165iO33+LspEOlCq8HxCx0p6kY7+etc+W2Gm4ilvEkrA=="],
+    "@flowscripter/dynamic-cli-framework": ["@flowscripter/dynamic-cli-framework@2.3.3", "", { "dependencies": { "@flowscripter/dynamic-cli-framework-api": "^1.2.0", "@flowscripter/dynamic-plugin-framework": "1.11.1", "emphasize": "^7.0.0", "fastest-levenshtein": "^1.0.16", "figlet": "^1.11.0", "highlight.js": "^11.11.1", "prettier": "^3.9.4", "semver": "^7.7.3", "supports-color": "^10.2.2", "supports-terminal-graphics": "^0.1.0" }, "peerDependencies": { "typescript": "^6.0.3" } }, "sha512-neY8YtiBHMU8IkBU1k5i1wECbDrDG4J1eyLbTi4RZwEIqzDl285/QLbXbEuNAnHiLZTphN/2YEDaEJxQ94mqnA=="],
 
     "@flowscripter/dynamic-cli-framework-api": ["@flowscripter/dynamic-cli-framework-api@1.2.0", "", { "peerDependencies": { "typescript": "^7.0.2" } }, "sha512-ajR6PwQQwsQN96OH3OwO0SH5h3TGY3lLPM5lIYNUCpUXrOZ9MYJtsXvDcDKz8U/heWe0FBJeRY0nsNDJV4p9Vw=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "@flowscripter/example-cli",
       "dependencies": {
-        "@flowscripter/dynamic-cli-framework": "2.3.1",
+        "@flowscripter/dynamic-cli-framework": "2.3.2",
         "@flowscripter/dynamic-cli-framework-api": "^1.2.0",
         "@flowscripter/dynamic-plugin-framework": "1.11.1",
       },
@@ -21,7 +21,7 @@
     },
   },
   "packages": {
-    "@flowscripter/dynamic-cli-framework": ["@flowscripter/dynamic-cli-framework@2.3.1", "", { "dependencies": { "@flowscripter/dynamic-cli-framework-api": "^1.2.0", "@flowscripter/dynamic-plugin-framework": "1.11.1", "emphasize": "^7.0.0", "fastest-levenshtein": "^1.0.16", "figlet": "^1.11.0", "highlight.js": "^11.11.1", "prettier": "^3.9.4", "semver": "^7.7.3", "supports-color": "^10.2.2", "supports-terminal-graphics": "^0.1.0" }, "peerDependencies": { "typescript": "^6.0.3" } }, "sha512-Fbj+GvAy4p4+bpuWvm/jfyeOyhcO7WAs9QWDc4HdHN4A/zyKpRSGaOEA5CH9LIcllR0che2UPFJvFqAuqb40qg=="],
+    "@flowscripter/dynamic-cli-framework": ["@flowscripter/dynamic-cli-framework@2.3.2", "", { "dependencies": { "@flowscripter/dynamic-cli-framework-api": "^1.2.0", "@flowscripter/dynamic-plugin-framework": "1.11.1", "emphasize": "^7.0.0", "fastest-levenshtein": "^1.0.16", "figlet": "^1.11.0", "highlight.js": "^11.11.1", "prettier": "^3.9.4", "semver": "^7.7.3", "supports-color": "^10.2.2", "supports-terminal-graphics": "^0.1.0" }, "peerDependencies": { "typescript": "^6.0.3" } }, "sha512-AC7ad5pAf9EMLCrWiWw269SvZAaG/LO4f487Swyuvv165iO33+LspEOlCq8HxCx0p6kY7+etc+W2Gm4ilvEkrA=="],
 
     "@flowscripter/dynamic-cli-framework-api": ["@flowscripter/dynamic-cli-framework-api@1.2.0", "", { "peerDependencies": { "typescript": "^7.0.2" } }, "sha512-ajR6PwQQwsQN96OH3OwO0SH5h3TGY3lLPM5lIYNUCpUXrOZ9MYJtsXvDcDKz8U/heWe0FBJeRY0nsNDJV4p9Vw=="],
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@flowscripter/dynamic-cli-framework": "2.3.1",
+    "@flowscripter/dynamic-cli-framework": "2.3.2",
     "@flowscripter/dynamic-cli-framework-api": "^1.2.0",
     "@flowscripter/dynamic-plugin-framework": "1.11.1"
   },

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@flowscripter/dynamic-cli-framework": "2.3.2",
+    "@flowscripter/dynamic-cli-framework": "2.3.3",
     "@flowscripter/dynamic-cli-framework-api": "^1.2.0",
     "@flowscripter/dynamic-plugin-framework": "1.11.1"
   },


### PR DESCRIPTION
## Summary
- Bumps `@flowscripter/dynamic-cli-framework` to 2.3.2, which fixes the upgrade-check timeout issue that was causing the `plugin:add` functional test to hang in CI (flowscripter/dynamic-cli-framework#132).

## Test plan
- [x] `bun install`, `bunx tsc --noEmit`, `bunx oxlint`, `bun test` all pass
- [x] Ran the full functional test suite locally against a binary built with 2.3.2: `plugin.feature` and `upgrade.feature` all pass (previously `plugin:add` hung for 60s+)
- [x] One unrelated pre-existing flaky scenario (`No completions after global command with trailing space`) fails only when run as part of the full suite, passes in isolation - not related to this change

https://claude.ai/code/session_01MFgq62zjHr1T1L2EdMkPa9