### PR TITLE
feat: switch to launchMultiCommandCLI with pluginServiceEnabled

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,9 +5,9 @@
     "": {
       "name": "@flowscripter/example-cli",
       "dependencies": {
-        "@flowscripter/dynamic-cli-framework": "^3.0.2",
-        "@flowscripter/dynamic-cli-framework-api": "^1.2.0",
-        "@flowscripter/dynamic-plugin-framework": "1.11.1",
+        "@flowscripter/dynamic-cli-framework": "4.0.0",
+        "@flowscripter/dynamic-cli-framework-api": "^1.5.0",
+        "@flowscripter/dynamic-plugin-framework": "2.0.0",
       },
       "devDependencies": {
         "@types/bun": "^1.3.14",
@@ -21,11 +21,11 @@
     },
   },
   "packages": {
-    "@flowscripter/dynamic-cli-framework": ["@flowscripter/dynamic-cli-framework@3.0.2", "", { "dependencies": { "@flowscripter/dynamic-cli-framework-api": "^1.4.1", "@flowscripter/dynamic-plugin-framework": "1.12.0", "emphasize": "^7.0.0", "fastest-levenshtein": "^1.0.16", "figlet": "^1.11.0", "highlight.js": "^11.11.1", "prettier": "^3.9.4", "semver": "^7.7.3", "supports-color": "^10.2.2", "supports-terminal-graphics": "^0.1.0" }, "peerDependencies": { "typescript": "^6.0.3" } }, "sha512-LbUyCcyzrZLZr+yU/K1sjgbBtkZK3vSiT0jA2jMYhg9TnT5Q7uPgNdbmRC3hXJ/8HRe+wr02lsgeJHnpbrGfDg=="],
+    "@flowscripter/dynamic-cli-framework": ["@flowscripter/dynamic-cli-framework@4.0.0", "", { "dependencies": { "@flowscripter/dynamic-cli-framework-api": "^1.5.0", "@flowscripter/dynamic-plugin-framework": "2.0.0", "emphasize": "^7.0.0", "fastest-levenshtein": "^1.0.16", "figlet": "^1.11.0", "highlight.js": "^11.11.1", "prettier": "^3.9.4", "semver": "^7.7.3", "supports-color": "^10.2.2", "supports-terminal-graphics": "^0.1.0" }, "peerDependencies": { "typescript": "^6.0.3" } }, "sha512-khzIXzaLWNHzbNrNMH7TrDFyAwclPnu4CrsRgL+IYU3nfnsN39K5pwd1MAKTFYBQddqxVa/ZMOFbPRMwz1el4w=="],
 
-    "@flowscripter/dynamic-cli-framework-api": ["@flowscripter/dynamic-cli-framework-api@1.2.0", "", { "peerDependencies": { "typescript": "^7.0.2" } }, "sha512-ajR6PwQQwsQN96OH3OwO0SH5h3TGY3lLPM5lIYNUCpUXrOZ9MYJtsXvDcDKz8U/heWe0FBJeRY0nsNDJV4p9Vw=="],
+    "@flowscripter/dynamic-cli-framework-api": ["@flowscripter/dynamic-cli-framework-api@1.5.0", "", { "peerDependencies": { "typescript": "^7.0.2" } }, "sha512-Tjs5rtaL7kEVZAdO2bM1vdbzCp5R5qGJxRFif6T1uilV5qQaVF92t1R90ndjSSb9G9KnyTDdhHe+NbpDOllvtA=="],
 
-    "@flowscripter/dynamic-plugin-framework": ["@flowscripter/dynamic-plugin-framework@1.11.1", "", { "dependencies": { "semver": "^7.8.5" }, "peerDependencies": { "typescript": "^7.0.2" } }, "sha512-m8bioReoQzzm7uj3sxXLH7Haclyj1UWnPCSxy2QXvGQ2yp24H1GnzqohVnXo3JfBpJzmCUAaHT+lAhYu9Gh6Aw=="],
+    "@flowscripter/dynamic-plugin-framework": ["@flowscripter/dynamic-plugin-framework@2.0.0", "", { "dependencies": { "semver": "^7.8.5" }, "peerDependencies": { "typescript": "^7.0.2" } }, "sha512-LPq4JXqsWttvNgE7Z5fim3h78xfeF/754gL7yI4PMjxfIvAZeyJhqsUElXOMEzNIrY9bXTqVWQJBpKO0+Vl61A=="],
 
     "@oxfmt/binding-android-arm-eabi": ["@oxfmt/binding-android-arm-eabi@0.56.0", "", { "os": "android", "cpu": "arm" }, "sha512-CSCxi7ovYojgfdPOdUb9T508HKeAdDIKeRGg7x8IZwVJrWz9gVgX7MbUnFqtQAE4QvoNo07mj2JlwnOzJw4qqA=="],
 
@@ -148,10 +148,6 @@
     "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
 
     "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
-
-    "@flowscripter/dynamic-cli-framework/@flowscripter/dynamic-cli-framework-api": ["@flowscripter/dynamic-cli-framework-api@1.4.1", "", { "peerDependencies": { "typescript": "^7.0.2" } }, "sha512-2ZH4ZWVI051RXyqg8qbBB4RMydiqeXul6rJibgRbLhXaQHox19RR8vc1H/jRqUpet+Kq1e4yuNAahQC7LdywxA=="],
-
-    "@flowscripter/dynamic-cli-framework/@flowscripter/dynamic-plugin-framework": ["@flowscripter/dynamic-plugin-framework@1.12.0", "", { "dependencies": { "semver": "^7.8.5" }, "peerDependencies": { "typescript": "^7.0.2" } }, "sha512-wdwDTpwp34K4Eh0YwClb3OQMUUt5M6v9cgr5ugQ+uJi68cc2YtDiX7kyrPBZsjw8SSrpmLkgJ91jXJ/f61jqVQ=="],
 
     "bun-types/@types/node": ["@types/node@22.13.9", "", { "dependencies": { "undici-types": "~6.20.0" } }, "sha512-acBjXdRJ3A6Pb3tqnw9HZmyR3Fiol3aGxRCK1x3d+6CDAMjl7I649wpSd+yNURCjbOUGu9tqtLKnTGxmK6CyGw=="],
 

--- a/package.json
+++ b/package.json
@@ -24,9 +24,9 @@
     "access": "public"
   },
   "dependencies": {
-    "@flowscripter/dynamic-cli-framework": "3.0.2",
-    "@flowscripter/dynamic-cli-framework-api": "^1.2.0",
-    "@flowscripter/dynamic-plugin-framework": "1.11.1"
+    "@flowscripter/dynamic-cli-framework": "4.0.0",
+    "@flowscripter/dynamic-cli-framework-api": "^1.5.0",
+    "@flowscripter/dynamic-plugin-framework": "2.0.0"
   },
   "devDependencies": {
     "@types/bun": "^1.3.14",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,16 +2,11 @@ import {
   AsciiBannerGeneratorServiceProvider,
   BannerServiceProvider,
   DataDumpGeneratorServiceProvider,
-  launchDynamicPluginMultiCommandCLI,
+  launchMultiCommandCLI,
   SyntaxHighlighterServiceProvider,
   TreePrinterServiceProvider,
 } from "@flowscripter/dynamic-cli-framework";
 import { SupportedArch, SupportedOs } from "@flowscripter/dynamic-cli-framework-api";
-import {
-  NpmPluginManager,
-  NpmPluginRepository,
-  NpmjsPluginRepository,
-} from "@flowscripter/dynamic-plugin-framework";
 import demo from "./commands/demo.ts";
 import packageJson from "../package.json";
 import path from "node:path";
@@ -19,19 +14,8 @@ import os from "node:os";
 
 export async function cli(): Promise<void> {
   const pluginsDir = path.join(os.homedir(), ".example-cli", "plugins", "node_modules");
-  const pluginManager = new NpmPluginManager(
-    [
-      new NpmjsPluginRepository({
-        name: "npmjs",
-        registryUrl: "https://registry.npmjs.org",
-        packageJsonNamespace: "dynamic-cli-framework",
-      }),
-    ],
-    new NpmPluginRepository(pluginsDir, "dynamic-cli-framework"),
-  );
 
-  await launchDynamicPluginMultiCommandCLI(
-    pluginManager,
+  await launchMultiCommandCLI(
     [demo],
     "Simple example CLI using dynamic-cli-framework.",
     "example-cli",
@@ -52,6 +36,16 @@ export async function cli(): Promise<void> {
       imagePrinterServiceEnabled: true,
       spawnServiceEnabled: true,
       upgradeServiceEnabled: true,
+      pluginServiceEnabled: true,
+      pluginServiceRemoteConfig: {
+        name: "npmjs",
+        registryUrl: "https://registry.npmjs.org",
+        packageJsonNamespace: "dynamic-cli-framework",
+      },
+      pluginServiceLocalConfig: {
+        nodeModulesPath: pluginsDir,
+        packageJsonNamespace: "dynamic-cli-framework",
+      },
       upgradeLocationsConfig: {
         supportedPlatforms: [
           { os: SupportedOs.LINUX, arch: SupportedArch.X64 },

--- a/src/commands/configuration.ts
+++ b/src/commands/configuration.ts
@@ -7,6 +7,7 @@ import {
   type PrinterService,
   type SubCommand,
 } from "@flowscripter/dynamic-cli-framework";
+import { Secret } from "@flowscripter/dynamic-cli-framework-api";
 
 const configuration: SubCommand = {
   name: "configuration",
@@ -20,21 +21,21 @@ const configuration: SubCommand = {
     // --- Key-Value Storage ---
     await printerService.print("--- Key-Value Storage ---\n");
 
-    await keyValueService.setKey("demo-string", "hello world");
-    await keyValueService.setKey("demo-number", "42");
-    await keyValueService.setKey("demo-json", '{"enabled":true,"retries":3}');
+    await keyValueService.set("demo-string", "hello world");
+    await keyValueService.set("demo-number", "42");
+    await keyValueService.set("demo-json", '{"enabled":true,"retries":3}');
 
     const keys = ["demo-string", "demo-number", "demo-json"];
     for (const key of keys) {
-      const value = await keyValueService.getKey(key);
+      const value = await keyValueService.get(key);
       await printerService.print(`  ${key} = ${value}\n`);
     }
 
-    const missing = await keyValueService.hasKey("demo-nonexistent");
+    const missing = await keyValueService.has("demo-nonexistent");
     await printerService.print(`  demo-nonexistent exists: ${missing}\n`);
 
     for (const key of keys) {
-      await keyValueService.deleteKey(key);
+      await keyValueService.delete(key);
     }
     await printerService.print("Cleaned up keys\n");
 
@@ -42,17 +43,17 @@ const configuration: SubCommand = {
     await printerService.print("--- Secret Storage ---\n");
 
     try {
-      await keyValueService.setKey("demo-api-key", "sk-secret-12345", true);
+      await keyValueService.set("demo-api-key", new Secret("sk-secret-12345"));
       await printerService.print("Stored secret: demo-api-key\n");
 
-      const exists = await keyValueService.hasKey("demo-api-key");
+      const exists = await keyValueService.has("demo-api-key");
       await printerService.print(`Key exists: ${exists}\n`);
 
-      const secret = await keyValueService.getKey("demo-api-key");
+      const secret = await keyValueService.get<string>("demo-api-key");
       const masked = secret.substring(0, 3) + "***";
       await printerService.print(`Retrieved secret (masked): ${masked}\n`);
 
-      await keyValueService.deleteKey("demo-api-key");
+      await keyValueService.delete("demo-api-key");
       await printerService.print("Deleted secret: demo-api-key\n");
     } catch (error) {
       await printerService.warn(


### PR DESCRIPTION
## Summary
- Drop the manual `NpmPluginManager`/`NpmPluginRepository`/`NpmjsPluginRepository` construction and `launchDynamicPluginMultiCommandCLI` call in `src/cli.ts` in favor of `launchMultiCommandCLI` with the new `pluginServiceEnabled`/`pluginServiceRemoteConfig`/`pluginServiceLocalConfig` options on `BaseCLIFeatureOptions`.
- Part of a coordinated refactor collapsing dynamic plugin support into `DefaultRuntimeCLI`/`BaseCLI` across three repos.

## Depends on
- flowscripter/dynamic-plugin-framework#100 (adds `NpmjsPluginRepositoryConfig`/`NpmPluginRepositoryConfig`)
- flowscripter/dynamic-cli-framework#135 (adds `PluginServiceProvider`, removes `DynamicPluginRuntimeCLI`/`launchDynamicPluginMultiCommandCLI`)

This PR's `bun install`/CI will only resolve correctly once those two are merged/released and this repo's `package.json` pins are bumped to the new versions - that bump is not included here since the versions don't exist yet.

## Test plan
- [x] `bunx tsc --noEmit` clean (verified locally via `bun link` against the two dependent branches)
- [x] `bun test` passes (1 test)
- [x] `bunx oxlint .` / `bunx oxfmt --check .` clean
- [ ] `functional_tests/features/plugin.feature` (Behave, requires published `@flowscripter/example-cli-plugin` + network) - unchanged, should pass once dependency versions are bumped and the executable is rebuilt
- [ ] Bump `@flowscripter/dynamic-cli-framework`/`@flowscripter/dynamic-plugin-framework` versions in `package.json` once the two dependency PRs are released