### PR TITLE
refactor: rename value type imports to match dynamic-cli-framework-api refactor

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "@flowscripter/example-cli",
       "dependencies": {
-        "@flowscripter/dynamic-cli-framework": "2.3.3",
+        "@flowscripter/dynamic-cli-framework": "3.0.0",
         "@flowscripter/dynamic-cli-framework-api": "^1.2.0",
         "@flowscripter/dynamic-plugin-framework": "1.11.1",
       },
@@ -21,7 +21,7 @@
     },
   },
   "packages": {
-    "@flowscripter/dynamic-cli-framework": ["@flowscripter/dynamic-cli-framework@2.3.3", "", { "dependencies": { "@flowscripter/dynamic-cli-framework-api": "^1.2.0", "@flowscripter/dynamic-plugin-framework": "1.11.1", "emphasize": "^7.0.0", "fastest-levenshtein": "^1.0.16", "figlet": "^1.11.0", "highlight.js": "^11.11.1", "prettier": "^3.9.4", "semver": "^7.7.3", "supports-color": "^10.2.2", "supports-terminal-graphics": "^0.1.0" }, "peerDependencies": { "typescript": "^6.0.3" } }, "sha512-neY8YtiBHMU8IkBU1k5i1wECbDrDG4J1eyLbTi4RZwEIqzDl285/QLbXbEuNAnHiLZTphN/2YEDaEJxQ94mqnA=="],
+    "@flowscripter/dynamic-cli-framework": ["@flowscripter/dynamic-cli-framework@3.0.0", "", { "dependencies": { "@flowscripter/dynamic-cli-framework-api": "^1.4.1", "@flowscripter/dynamic-plugin-framework": "1.12.0", "emphasize": "^7.0.0", "fastest-levenshtein": "^1.0.16", "figlet": "^1.11.0", "highlight.js": "^11.11.1", "prettier": "^3.9.4", "semver": "^7.7.3", "supports-color": "^10.2.2", "supports-terminal-graphics": "^0.1.0" }, "peerDependencies": { "typescript": "^6.0.3" } }, "sha512-Ra44QIQ6Ff2883BgVOYiP+4IwUZ9U6a2NdPxriul/xIsLAwKZjbk4BuedvntodjQrAiQYz87qcw1HC4Zb4sxow=="],
 
     "@flowscripter/dynamic-cli-framework-api": ["@flowscripter/dynamic-cli-framework-api@1.2.0", "", { "peerDependencies": { "typescript": "^7.0.2" } }, "sha512-ajR6PwQQwsQN96OH3OwO0SH5h3TGY3lLPM5lIYNUCpUXrOZ9MYJtsXvDcDKz8U/heWe0FBJeRY0nsNDJV4p9Vw=="],
 
@@ -148,6 +148,10 @@
     "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
 
     "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
+
+    "@flowscripter/dynamic-cli-framework/@flowscripter/dynamic-cli-framework-api": ["@flowscripter/dynamic-cli-framework-api@1.4.1", "", { "peerDependencies": { "typescript": "^7.0.2" } }, "sha512-2ZH4ZWVI051RXyqg8qbBB4RMydiqeXul6rJibgRbLhXaQHox19RR8vc1H/jRqUpet+Kq1e4yuNAahQC7LdywxA=="],
+
+    "@flowscripter/dynamic-cli-framework/@flowscripter/dynamic-plugin-framework": ["@flowscripter/dynamic-plugin-framework@1.12.0", "", { "dependencies": { "semver": "^7.8.5" }, "peerDependencies": { "typescript": "^7.0.2" } }, "sha512-wdwDTpwp34K4Eh0YwClb3OQMUUt5M6v9cgr5ugQ+uJi68cc2YtDiX7kyrPBZsjw8SSrpmLkgJ91jXJ/f61jqVQ=="],
 
     "bun-types/@types/node": ["@types/node@22.13.9", "", { "dependencies": { "undici-types": "~6.20.0" } }, "sha512-acBjXdRJ3A6Pb3tqnw9HZmyR3Fiol3aGxRCK1x3d+6CDAMjl7I649wpSd+yNURCjbOUGu9tqtLKnTGxmK6CyGw=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "@flowscripter/example-cli",
       "dependencies": {
-        "@flowscripter/dynamic-cli-framework": "3.0.1",
+        "@flowscripter/dynamic-cli-framework": "^3.0.2",
         "@flowscripter/dynamic-cli-framework-api": "^1.2.0",
         "@flowscripter/dynamic-plugin-framework": "1.11.1",
       },
@@ -21,7 +21,7 @@
     },
   },
   "packages": {
-    "@flowscripter/dynamic-cli-framework": ["@flowscripter/dynamic-cli-framework@3.0.1", "", { "dependencies": { "@flowscripter/dynamic-cli-framework-api": "^1.4.1", "@flowscripter/dynamic-plugin-framework": "1.12.0", "emphasize": "^7.0.0", "fastest-levenshtein": "^1.0.16", "figlet": "^1.11.0", "highlight.js": "^11.11.1", "prettier": "^3.9.4", "semver": "^7.7.3", "supports-color": "^10.2.2", "supports-terminal-graphics": "^0.1.0" }, "peerDependencies": { "typescript": "^6.0.3" } }, "sha512-QRuNcfx7ATznoq2p9BgU63UHnq20MSfR0sOXE2zLmeOXJpslhJVjwecMFTwSEQHntI7fbygnzo6vuA5OH6agAQ=="],
+    "@flowscripter/dynamic-cli-framework": ["@flowscripter/dynamic-cli-framework@3.0.2", "", { "dependencies": { "@flowscripter/dynamic-cli-framework-api": "^1.4.1", "@flowscripter/dynamic-plugin-framework": "1.12.0", "emphasize": "^7.0.0", "fastest-levenshtein": "^1.0.16", "figlet": "^1.11.0", "highlight.js": "^11.11.1", "prettier": "^3.9.4", "semver": "^7.7.3", "supports-color": "^10.2.2", "supports-terminal-graphics": "^0.1.0" }, "peerDependencies": { "typescript": "^6.0.3" } }, "sha512-LbUyCcyzrZLZr+yU/K1sjgbBtkZK3vSiT0jA2jMYhg9TnT5Q7uPgNdbmRC3hXJ/8HRe+wr02lsgeJHnpbrGfDg=="],
 
     "@flowscripter/dynamic-cli-framework-api": ["@flowscripter/dynamic-cli-framework-api@1.2.0", "", { "peerDependencies": { "typescript": "^7.0.2" } }, "sha512-ajR6PwQQwsQN96OH3OwO0SH5h3TGY3lLPM5lIYNUCpUXrOZ9MYJtsXvDcDKz8U/heWe0FBJeRY0nsNDJV4p9Vw=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "@flowscripter/example-cli",
       "dependencies": {
-        "@flowscripter/dynamic-cli-framework": "3.0.0",
+        "@flowscripter/dynamic-cli-framework": "3.0.1",
         "@flowscripter/dynamic-cli-framework-api": "^1.2.0",
         "@flowscripter/dynamic-plugin-framework": "1.11.1",
       },
@@ -21,7 +21,7 @@
     },
   },
   "packages": {
-    "@flowscripter/dynamic-cli-framework": ["@flowscripter/dynamic-cli-framework@3.0.0", "", { "dependencies": { "@flowscripter/dynamic-cli-framework-api": "^1.4.1", "@flowscripter/dynamic-plugin-framework": "1.12.0", "emphasize": "^7.0.0", "fastest-levenshtein": "^1.0.16", "figlet": "^1.11.0", "highlight.js": "^11.11.1", "prettier": "^3.9.4", "semver": "^7.7.3", "supports-color": "^10.2.2", "supports-terminal-graphics": "^0.1.0" }, "peerDependencies": { "typescript": "^6.0.3" } }, "sha512-Ra44QIQ6Ff2883BgVOYiP+4IwUZ9U6a2NdPxriul/xIsLAwKZjbk4BuedvntodjQrAiQYz87qcw1HC4Zb4sxow=="],
+    "@flowscripter/dynamic-cli-framework": ["@flowscripter/dynamic-cli-framework@3.0.1", "", { "dependencies": { "@flowscripter/dynamic-cli-framework-api": "^1.4.1", "@flowscripter/dynamic-plugin-framework": "1.12.0", "emphasize": "^7.0.0", "fastest-levenshtein": "^1.0.16", "figlet": "^1.11.0", "highlight.js": "^11.11.1", "prettier": "^3.9.4", "semver": "^7.7.3", "supports-color": "^10.2.2", "supports-terminal-graphics": "^0.1.0" }, "peerDependencies": { "typescript": "^6.0.3" } }, "sha512-QRuNcfx7ATznoq2p9BgU63UHnq20MSfR0sOXE2zLmeOXJpslhJVjwecMFTwSEQHntI7fbygnzo6vuA5OH6agAQ=="],
 
     "@flowscripter/dynamic-cli-framework-api": ["@flowscripter/dynamic-cli-framework-api@1.2.0", "", { "peerDependencies": { "typescript": "^7.0.2" } }, "sha512-ajR6PwQQwsQN96OH3OwO0SH5h3TGY3lLPM5lIYNUCpUXrOZ9MYJtsXvDcDKz8U/heWe0FBJeRY0nsNDJV4p9Vw=="],
 

--- a/functional_tests/features/support/pexpect_wrapper.py
+++ b/functional_tests/features/support/pexpect_wrapper.py
@@ -40,8 +40,6 @@ class PExpectWrapper:
                 found = next_line
                 break
 
-        # TEMPORARY: surface the full captured output on failure to diagnose an
-        # intermittent macOS "upgrade already up to date" assertion failure.
         assert found != '', 'expected "{}" in output, got: {!r}'.format(message, remaining)
 
     def expect_eof(self):

--- a/functional_tests/features/support/pexpect_wrapper.py
+++ b/functional_tests/features/support/pexpect_wrapper.py
@@ -31,6 +31,7 @@ class PExpectWrapper:
     def expect(self, message):
         assert self.child is not None
 
+        remaining = list(self.output)
         found = ''
         while len(self.output) > 0:
             next_line = self.output.pop(0)
@@ -39,7 +40,9 @@ class PExpectWrapper:
                 found = next_line
                 break
 
-        assert found != '', 'expected {} in output'.format(message)
+        # TEMPORARY: surface the full captured output on failure to diagnose an
+        # intermittent macOS "upgrade already up to date" assertion failure.
+        assert found != '', 'expected "{}" in output, got: {!r}'.format(message, remaining)
 
     def expect_eof(self):
         assert self.child is not None

--- a/functional_tests/features/support/subprocess_wrapper.py
+++ b/functional_tests/features/support/subprocess_wrapper.py
@@ -15,14 +15,23 @@ class SubprocessWrapper:
 
     def run(self, args='', stdin_text=None, timeout=30):
         cmd = [self.executable] + (shlex.split(args) if args else [])
-        log.debug('running: {}'.format(cmd))
-        result = subprocess.run(
-            cmd, capture_output=True, text=True, timeout=timeout, input=stdin_text,
-            encoding='utf-8', errors='replace'
-        )
+        # TEMPORARY: plain print() (not logging.debug) so this shows up in CI output regardless
+        # of behave's default log-capture level, while diagnosing a Windows-only hang in
+        # `plugin:add`. Remove once root-caused.
+        print('DEBUG: running: {}'.format(cmd), flush=True)
+        try:
+            result = subprocess.run(
+                cmd, capture_output=True, text=True, timeout=timeout, input=stdin_text,
+                encoding='utf-8', errors='replace'
+            )
+        except subprocess.TimeoutExpired as e:
+            print('DEBUG: TIMED OUT after {}s'.format(timeout), flush=True)
+            print('DEBUG: partial stdout: {!r}'.format(e.stdout), flush=True)
+            print('DEBUG: partial stderr: {!r}'.format(e.stderr), flush=True)
+            raise
         self.stdout = result.stdout
         self.stderr = result.stderr
         self.returncode = result.returncode
-        log.debug('stdout: {!r}'.format(self.stdout))
-        log.debug('stderr: {!r}'.format(self.stderr))
-        log.debug('returncode: {}'.format(self.returncode))
+        print('DEBUG: stdout: {!r}'.format(self.stdout), flush=True)
+        print('DEBUG: stderr: {!r}'.format(self.stderr), flush=True)
+        print('DEBUG: returncode: {}'.format(self.returncode), flush=True)

--- a/functional_tests/features/support/subprocess_wrapper.py
+++ b/functional_tests/features/support/subprocess_wrapper.py
@@ -15,23 +15,11 @@ class SubprocessWrapper:
 
     def run(self, args='', stdin_text=None, timeout=30):
         cmd = [self.executable] + (shlex.split(args) if args else [])
-        # TEMPORARY: plain print() (not logging.debug) so this shows up in CI output regardless
-        # of behave's default log-capture level, while diagnosing a Windows-only hang in
-        # `plugin:add`. Remove once root-caused.
-        print('DEBUG: running: {}'.format(cmd), flush=True)
-        try:
-            result = subprocess.run(
-                cmd, capture_output=True, text=True, timeout=timeout, input=stdin_text,
-                encoding='utf-8', errors='replace'
-            )
-        except subprocess.TimeoutExpired as e:
-            print('DEBUG: TIMED OUT after {}s'.format(timeout), flush=True)
-            print('DEBUG: partial stdout: {!r}'.format(e.stdout), flush=True)
-            print('DEBUG: partial stderr: {!r}'.format(e.stderr), flush=True)
-            raise
+        log.debug('running: {}'.format(cmd))
+        result = subprocess.run(
+            cmd, capture_output=True, text=True, timeout=timeout, input=stdin_text,
+            encoding='utf-8', errors='replace'
+        )
         self.stdout = result.stdout
         self.stderr = result.stderr
         self.returncode = result.returncode
-        print('DEBUG: stdout: {!r}'.format(self.stdout), flush=True)
-        print('DEBUG: stderr: {!r}'.format(self.stderr), flush=True)
-        print('DEBUG: returncode: {}'.format(self.returncode), flush=True)

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@flowscripter/dynamic-cli-framework": "2.3.3",
+    "@flowscripter/dynamic-cli-framework": "3.0.0",
     "@flowscripter/dynamic-cli-framework-api": "^1.2.0",
     "@flowscripter/dynamic-plugin-framework": "1.11.1"
   },

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@flowscripter/dynamic-cli-framework": "3.0.0",
+    "@flowscripter/dynamic-cli-framework": "3.0.1",
     "@flowscripter/dynamic-cli-framework-api": "^1.2.0",
     "@flowscripter/dynamic-plugin-framework": "1.11.1"
   },

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@flowscripter/dynamic-cli-framework": "3.0.1",
+    "@flowscripter/dynamic-cli-framework": "3.0.2",
     "@flowscripter/dynamic-cli-framework-api": "^1.2.0",
     "@flowscripter/dynamic-plugin-framework": "1.11.1"
   },

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -51,6 +51,7 @@ export async function cli(): Promise<void> {
       completionServiceEnabled: true,
       imagePrinterServiceEnabled: true,
       spawnServiceEnabled: true,
+      fetchServiceEnabled: true,
       upgradeServiceEnabled: true,
       upgradeLocationsConfig: {
         supportedPlatforms: [

--- a/src/commands/arg-parsing.ts
+++ b/src/commands/arg-parsing.ts
@@ -1,6 +1,6 @@
 import {
-  type ArgumentValues,
-  ArgumentValueTypeName,
+  type Values,
+  ValueTypeName,
   ComplexValueTypeName,
   type Context,
   PRINTER_SERVICE_ID,
@@ -17,21 +17,21 @@ const argParsing: SubCommand = {
     {
       name: "booleanOption",
       description: "A boolean option",
-      type: ArgumentValueTypeName.BOOLEAN,
+      type: ValueTypeName.BOOLEAN,
       shortAlias: "b",
       isOptional: true,
     },
     {
       name: "numberOption",
       description: "A number option",
-      type: ArgumentValueTypeName.NUMBER,
+      type: ValueTypeName.NUMBER,
       shortAlias: "n",
       isOptional: true,
     },
     {
       name: "stringOption",
       description: "A string option",
-      type: ArgumentValueTypeName.STRING,
+      type: ValueTypeName.STRING,
       shortAlias: "s",
       isOptional: true,
     },
@@ -45,7 +45,7 @@ const argParsing: SubCommand = {
         {
           name: "numberSubOption",
           description: "A number sub-option",
-          type: ArgumentValueTypeName.NUMBER,
+          type: ValueTypeName.NUMBER,
           shortAlias: "n",
           isArray: true,
         },
@@ -56,17 +56,17 @@ const argParsing: SubCommand = {
     {
       name: "booleanPositional",
       description: "A boolean positional",
-      type: ArgumentValueTypeName.BOOLEAN,
+      type: ValueTypeName.BOOLEAN,
     },
     {
       name: "numberPositional",
       description: "A number positional",
-      type: ArgumentValueTypeName.NUMBER,
+      type: ValueTypeName.NUMBER,
     },
     {
       name: "stringPositional",
       description: "A string positional",
-      type: ArgumentValueTypeName.STRING,
+      type: ValueTypeName.STRING,
     },
   ],
   usageExamples: [
@@ -114,7 +114,7 @@ const argParsing: SubCommand = {
       ],
     },
   ],
-  async execute(context: Context, argumentValues: ArgumentValues): Promise<void> {
+  async execute(context: Context, argumentValues: Values): Promise<void> {
     const printerService = context.getServiceById(PRINTER_SERVICE_ID) as PrinterService;
     const highlighterService = context.getServiceById(
       SYNTAX_HIGHLIGHTER_SERVICE_ID,

--- a/src/commands/banners.ts
+++ b/src/commands/banners.ts
@@ -1,5 +1,5 @@
 import {
-  type ArgumentValues,
+  type Values,
   ASCII_BANNER_GENERATOR_SERVICE_ID,
   type AsciiBannerGeneratorService,
   ChiselFontAsciiBannerGeneratorService,
@@ -14,7 +14,7 @@ const banners: SubCommand = {
   description: "Demonstrates chisel font ASCII banner and ASCII banner subtitle",
   options: [],
   positionals: [],
-  execute: async (context: Context, _argumentValues: ArgumentValues): Promise<void> => {
+  execute: async (context: Context, _argumentValues: Values): Promise<void> => {
     const printerService = context.getServiceById(PRINTER_SERVICE_ID) as PrinterService;
     const asciiBannerService = context.getServiceById(
       ASCII_BANNER_GENERATOR_SERVICE_ID,

--- a/src/commands/completion.ts
+++ b/src/commands/completion.ts
@@ -1,6 +1,6 @@
 import process from "node:process";
 import {
-  type ArgumentValues,
+  type Values,
   COMPLETION_SERVICE_ID,
   type CompletionService,
   type Context,
@@ -15,7 +15,7 @@ const completion: SubCommand = {
   description: "Demonstrates shell completion service",
   options: [],
   positionals: [],
-  execute: async (context: Context, _argumentValues: ArgumentValues): Promise<void> => {
+  execute: async (context: Context, _argumentValues: Values): Promise<void> => {
     const printerService = context.getServiceById(PRINTER_SERVICE_ID) as PrinterService;
     const completionService = context.getServiceById(COMPLETION_SERVICE_ID) as CompletionService;
 

--- a/src/commands/configuration.ts
+++ b/src/commands/configuration.ts
@@ -1,5 +1,5 @@
 import {
-  type ArgumentValues,
+  type Values,
   type Context,
   KEY_VALUE_SERVICE_ID,
   type KeyValueService,
@@ -13,7 +13,7 @@ const configuration: SubCommand = {
   description: "Demonstrates secrets storage and key-value service",
   options: [],
   positionals: [],
-  async execute(context: Context, _argumentValues: ArgumentValues): Promise<void> {
+  async execute(context: Context, _argumentValues: Values): Promise<void> {
     const printerService = context.getServiceById(PRINTER_SERVICE_ID) as PrinterService;
     const keyValueService = context.getServiceById(KEY_VALUE_SERVICE_ID) as KeyValueService;
 

--- a/src/commands/image.ts
+++ b/src/commands/image.ts
@@ -1,5 +1,5 @@
 import {
-  type ArgumentValues,
+  type Values,
   type Context,
   IMAGE_PRINTER_SERVICE_ID,
   type ImagePrinterService,
@@ -14,7 +14,7 @@ const image: SubCommand = {
   description: "Demonstrates image rendering in the terminal",
   options: [],
   positionals: [],
-  execute: async (context: Context, _argumentValues: ArgumentValues): Promise<void> => {
+  execute: async (context: Context, _argumentValues: Values): Promise<void> => {
     const printerService = context.getServiceById(PRINTER_SERVICE_ID) as PrinterService;
     const imagePrinterService = context.getServiceById(
       IMAGE_PRINTER_SERVICE_ID,

--- a/src/commands/interruption.ts
+++ b/src/commands/interruption.ts
@@ -1,5 +1,5 @@
 import {
-  type ArgumentValues,
+  type Values,
   type Context,
   Icon,
   PRINTER_SERVICE_ID,
@@ -18,7 +18,7 @@ const interruption: SubCommand = {
   description: "Demonstrates graceful shutdown with signal handling (press Ctrl+C to interrupt)",
   options: [],
   positionals: [],
-  execute: async (context: Context, _argumentValues: ArgumentValues): Promise<void> => {
+  execute: async (context: Context, _argumentValues: Values): Promise<void> => {
     const printerService = context.getServiceById(PRINTER_SERVICE_ID) as PrinterService;
     const shutdownService = context.getServiceById(SHUTDOWN_SERVICE_ID) as ShutdownService;
 

--- a/src/commands/printing.ts
+++ b/src/commands/printing.ts
@@ -1,6 +1,6 @@
 import {
   Align,
-  type ArgumentValues,
+  type Values,
   ASCII_BANNER_GENERATOR_SERVICE_ID,
   type AsciiBannerGeneratorService,
   type Context,
@@ -31,7 +31,7 @@ const printing: SubCommand = {
   description: "Demonstrates printer, tree, table, data dump, and banner output features",
   options: [],
   positionals: [],
-  execute: async (context: Context, _argumentValues: ArgumentValues): Promise<void> => {
+  execute: async (context: Context, _argumentValues: Values): Promise<void> => {
     const printerService = context.getServiceById(PRINTER_SERVICE_ID) as PrinterService;
     const asciiBannerGenerator = context.getServiceById(
       ASCII_BANNER_GENERATOR_SERVICE_ID,

--- a/src/commands/prompting.ts
+++ b/src/commands/prompting.ts
@@ -1,6 +1,6 @@
 import {
-  type ArgumentValues,
-  ArgumentValueTypeName,
+  type Values,
+  ValueTypeName,
   type Context,
   PRINTER_SERVICE_ID,
   type PrinterService,
@@ -19,7 +19,7 @@ const prompting: SubCommand = {
     {
       name: "age",
       description: "Your age",
-      type: ArgumentValueTypeName.NUMBER,
+      type: ValueTypeName.NUMBER,
       shortAlias: "a",
       isOptional: true,
       validate: (value): string | undefined => {
@@ -35,7 +35,7 @@ const prompting: SubCommand = {
     {
       name: "name",
       description: "Your name (must be at least 2 characters)",
-      type: ArgumentValueTypeName.STRING,
+      type: ValueTypeName.STRING,
       validate: (value): string | undefined => {
         const str = value as string;
         if (str.length < 2) {
@@ -45,7 +45,7 @@ const prompting: SubCommand = {
       },
     },
   ],
-  async execute(context: Context, argumentValues: ArgumentValues): Promise<void> {
+  async execute(context: Context, argumentValues: Values): Promise<void> {
     const printerService = context.getServiceById(PRINTER_SERVICE_ID) as PrinterService;
     const prompterService = context.getServiceById(PROMPTER_SERVICE_ID) as PrompterService;
 


### PR DESCRIPTION
## Summary
- Renames `ArgumentValues` -> `Values` and `ArgumentValueTypeName` -> `ValueTypeName` across 8 command files (`arg-parsing.ts`, `banners.ts`, `completion.ts`, `configuration.ts`, `image.ts`, `interruption.ts`, `printing.ts`, `prompting.ts`), matching the type relocation/rename in `@flowscripter/dynamic-cli-framework-api`.
- `ComplexValueTypeName` is unchanged and untouched.
- Only type imports/annotations and enum-value usages were renamed; variable/parameter names (e.g. `argumentValues`) are unchanged.
- No changes to `package.json` dependency pins.

**Depends on:**
- flowscripter/dynamic-cli-framework-api#8 (rename PR, not yet merged)
- A corresponding `dynamic-cli-framework` re-export update (in progress on a `refactor/generic-value-types` branch/worktree in that repo, not yet a PR)

This PR should not be merged until those land and are released, since the published `@flowscripter/dynamic-cli-framework@2.3.3` still re-exports the old names.

## Test plan
- [x] `bunx tsc --noEmit` - passes, verified locally via `bun link` against the unpublished `dynamic-cli-framework-api` (branch `refactor/generic-value-types`) and a local worktree build of `dynamic-cli-framework` (same branch name, separate in-progress refactor) that already re-exports the new names in `dist/index.d.ts`
- [x] `bun test` - 1 pass
- [x] `bunx oxlint .` - clean
- [x] `bunx oxfmt --check .` - clean
- [ ] Full CI (`package.json` still pins published `dynamic-cli-framework@2.3.3`, so CI will fail typecheck until the upstream rename is merged/released and the dependency is bumped in a follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SvxRNHoMxUCQwEcuvr8h7G