### PR TITLE
fix: temporarily instrument plugin:add for intermittent Windows hang

### DIFF
--- a/functional_tests/features/support/subprocess_wrapper.py
+++ b/functional_tests/features/support/subprocess_wrapper.py
@@ -1,8 +1,27 @@
+import platform
 import shlex
 import subprocess
 import logging
 
 log = logging.getLogger("subprocess_wrapper")
+
+
+def _dump_process_tree():
+    # TEMPORARY: diagnosing an intermittent Windows-only hang in `plugin:add`. Dumps the OS
+    # process list on timeout so we can see whether a child npm/node process is stuck vs. our
+    # own process. Remove once root-caused.
+    try:
+        if platform.system() == 'Windows':
+            out = subprocess.run(
+                ['tasklist', '/v'], capture_output=True, text=True, timeout=10
+            ).stdout
+        else:
+            out = subprocess.run(
+                ['ps', '-ef'], capture_output=True, text=True, timeout=10
+            ).stdout
+        print('DEBUG: process list at timeout:\n{}'.format(out), flush=True)
+    except Exception as e:
+        print('DEBUG: failed to dump process list: {}'.format(e), flush=True)
 
 
 class SubprocessWrapper:
@@ -15,11 +34,24 @@ class SubprocessWrapper:
 
     def run(self, args='', stdin_text=None, timeout=30):
         cmd = [self.executable] + (shlex.split(args) if args else [])
-        log.debug('running: {}'.format(cmd))
-        result = subprocess.run(
-            cmd, capture_output=True, text=True, timeout=timeout, input=stdin_text,
-            encoding='utf-8', errors='replace'
-        )
+        # TEMPORARY: plain print() (not logging.debug) so this shows up in CI output regardless
+        # of behave's default log-capture level, while diagnosing an intermittent Windows-only
+        # hang in `plugin:add`. Remove once root-caused.
+        print('DEBUG: running: {}'.format(cmd), flush=True)
+        try:
+            result = subprocess.run(
+                cmd, capture_output=True, text=True, timeout=timeout, input=stdin_text,
+                encoding='utf-8', errors='replace'
+            )
+        except subprocess.TimeoutExpired as e:
+            print('DEBUG: TIMED OUT after {}s'.format(timeout), flush=True)
+            print('DEBUG: partial stdout: {!r}'.format(e.stdout), flush=True)
+            print('DEBUG: partial stderr: {!r}'.format(e.stderr), flush=True)
+            _dump_process_tree()
+            raise
         self.stdout = result.stdout
         self.stderr = result.stderr
         self.returncode = result.returncode
+        print('DEBUG: stdout: {!r}'.format(self.stdout), flush=True)
+        print('DEBUG: stderr: {!r}'.format(self.stderr), flush=True)
+        print('DEBUG: returncode: {}'.format(self.returncode), flush=True)


### PR DESCRIPTION
## Purpose
Temporary, throwaway PR to catch diagnostic output for an intermittent Windows-only hang in the `plugin:add` functional test scenario. It has recurred multiple times (most recently on the post-merge release build for #81: https://github.com/flowscripter/example-cli/actions/runs/30181468897), always as a full 60s timeout with no visible cause, but passes on retry - so the goal here is to run CI repeatedly until it reproduces with debug output attached, then read the logs and close this without merging.

## Changes
- `functional_tests/features/support/subprocess_wrapper.py`: unconditional `print(..., flush=True)` around the `plugin:add` subprocess call (bypasses behave's log-capture), plus a process-list dump (`tasklist /v` on Windows, `ps -ef` elsewhere) on timeout to distinguish a stuck child npm/node process from our own process hanging.

## Do not merge
This is diagnostic only. Once the hang reproduces and logs are captured, this PR should be closed without merging (or the instrumentation reverted before merge if the fix needs the same branch).