### PR TITLE
fix: reconfigure Windows console streams to UTF-8 for functional tests

### DIFF
--- a/functional_tests/features/environment.py
+++ b/functional_tests/features/environment.py
@@ -1,9 +1,18 @@
 import os
 import platform
+import sys
 
 from support.pexpect_wrapper import PExpectWrapper
 
 IS_WINDOWS = platform.system() == 'Windows'
+
+if IS_WINDOWS:
+    # Windows' legacy console codepage (e.g. cp1252) cannot encode several Unicode icons used
+    # in example-cli's coloured output (e.g. the U+203C alert icon), crashing behave's pretty
+    # formatter with UnicodeEncodeError whenever a failure message contains one. Reconfigure
+    # the streams to UTF-8, which covers them, before any output is written.
+    sys.stdout.reconfigure(encoding='utf-8', errors='replace')
+    sys.stderr.reconfigure(encoding='utf-8', errors='replace')
 
 
 def before_scenario(context, scenario):


### PR DESCRIPTION
## Summary
- `behave`'s pretty formatter crashes with `UnicodeEncodeError` on Windows whenever a captured failure message contains a character outside the legacy console codepage (e.g. `cp1252`) - specifically hit by the U+203C ('‼') alert icon used in example-cli's coloured output.
- This was masking real assertion failures (most recently an intermittent "No upgrade location is configured" failure) behind an unrelated crash trace, instead of showing the actual assertion message.

## Fix
- `functional_tests/features/environment.py`: on Windows, reconfigure `sys.stdout`/`sys.stderr` to UTF-8 (`errors='replace'`) at import time, before any output is written. This covers the Unicode icons the CLI emits and applies to local Windows runs too, not just CI.

## Test plan
- [x] Reviewed manually - straightforward stream reconfiguration, no logic change to test assertions
- [ ] CI: windows-latest test-executable run should no longer show `UnicodeEncodeError` traces when a scenario legitimately fails