### PR TITLE
chore: bump dynamic-cli-framework to 5.1.1 (fixes plugin:add Windows hang)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,9 +5,9 @@
     "": {
       "name": "@flowscripter/example-cli",
       "dependencies": {
-        "@flowscripter/dynamic-cli-framework": "5.0.5",
+        "@flowscripter/dynamic-cli-framework": "5.1.1",
         "@flowscripter/dynamic-cli-framework-api": "^1.5.0",
-        "@flowscripter/dynamic-plugin-framework": "2.0.3",
+        "@flowscripter/dynamic-plugin-framework": "2.1.1",
       },
       "devDependencies": {
         "@types/bun": "^1.3.14",
@@ -21,11 +21,11 @@
     },
   },
   "packages": {
-    "@flowscripter/dynamic-cli-framework": ["@flowscripter/dynamic-cli-framework@5.0.5", "", { "dependencies": { "@flowscripter/dynamic-cli-framework-api": "^2.0.0", "@flowscripter/dynamic-plugin-framework": "2.0.3", "emphasize": "^7.0.0", "fastest-levenshtein": "^1.0.16", "figlet": "^1.11.0", "highlight.js": "^11.11.1", "prettier": "^3.9.4", "semver": "^7.7.3", "supports-color": "^10.2.2", "supports-terminal-graphics": "^0.1.0" }, "peerDependencies": { "typescript": "^6.0.3" } }, "sha512-Rz5vJ7oDse4TRgC6l/cUdOO4e+9MPraVyGogWntdX+hSq+7akX+H4p4P+BlzuwyHwR/zDcjZZ2GOwdCtt36lmg=="],
+    "@flowscripter/dynamic-cli-framework": ["@flowscripter/dynamic-cli-framework@5.1.1", "", { "dependencies": { "@flowscripter/dynamic-cli-framework-api": "^2.0.0", "@flowscripter/dynamic-plugin-framework": "2.1.1", "emphasize": "^7.0.0", "fastest-levenshtein": "^1.0.16", "figlet": "^1.11.0", "highlight.js": "^11.11.1", "prettier": "^3.9.4", "semver": "^7.7.3", "supports-color": "^10.2.2", "supports-terminal-graphics": "^0.1.0" }, "peerDependencies": { "typescript": "^6.0.3" } }, "sha512-g/GVKxyWmGMzf/exd8th0xTBXmj2vyRNStUAjP1cBkxtz8SOpwXDinSE/rgbElaPQGo43HlLFyoHqriWQHKdbQ=="],
 
     "@flowscripter/dynamic-cli-framework-api": ["@flowscripter/dynamic-cli-framework-api@1.5.0", "", { "peerDependencies": { "typescript": "^7.0.2" } }, "sha512-Tjs5rtaL7kEVZAdO2bM1vdbzCp5R5qGJxRFif6T1uilV5qQaVF92t1R90ndjSSb9G9KnyTDdhHe+NbpDOllvtA=="],
 
-    "@flowscripter/dynamic-plugin-framework": ["@flowscripter/dynamic-plugin-framework@2.0.3", "", { "dependencies": { "semver": "^7.8.5" }, "peerDependencies": { "typescript": "^7.0.2" } }, "sha512-qyQn+4v/T0ugsdYRFPsvIU7z2nvY2D0ZVPJ9ZdW0KJCFImY1VB/2fYtCBVTjHK339QXcYM+jBHv5Pvuf0emgEw=="],
+    "@flowscripter/dynamic-plugin-framework": ["@flowscripter/dynamic-plugin-framework@2.1.1", "", { "dependencies": { "semver": "^7.8.5" }, "peerDependencies": { "typescript": "^7.0.2" } }, "sha512-0fHxgPAsb1xrnv3J8YdNtK0eOhTuKzM6J/fU4IYJEj5y8qlj7v1SZIO3+jvN3y8aEgYRxd6B2GAfXKk9WGR2Pg=="],
 
     "@oxfmt/binding-android-arm-eabi": ["@oxfmt/binding-android-arm-eabi@0.56.0", "", { "os": "android", "cpu": "arm" }, "sha512-CSCxi7ovYojgfdPOdUb9T508HKeAdDIKeRGg7x8IZwVJrWz9gVgX7MbUnFqtQAE4QvoNo07mj2JlwnOzJw4qqA=="],
 

--- a/package.json
+++ b/package.json
@@ -24,9 +24,9 @@
     "access": "public"
   },
   "dependencies": {
-    "@flowscripter/dynamic-cli-framework": "5.0.5",
+    "@flowscripter/dynamic-cli-framework": "5.1.1",
     "@flowscripter/dynamic-cli-framework-api": "^1.5.0",
-    "@flowscripter/dynamic-plugin-framework": "2.0.3"
+    "@flowscripter/dynamic-plugin-framework": "2.1.1"
   },
   "devDependencies": {
     "@types/bun": "^1.3.14",


### PR DESCRIPTION
## Summary
- Bumps \`@flowscripter/dynamic-cli-framework\` to \`5.1.1\` / \`@flowscripter/dynamic-plugin-framework\` to \`2.1.1\`, picking up the fix for the Windows-only \`plugin:add\` hang seen in PR #86's CI (runs 30626999894, jobs 91144471378 and 91152776252).
- Root cause: the install command's \`stdout\`/\`stderr\` were \`"inherit"\`ed, which on Windows duplicates our OS-level output handles into every process the child spawns in turn (\`cmd.exe\` -> \`bun.exe\` -> further helper processes). If any of those grandchildren doesn't close its copy promptly, a caller reading our output can block indefinitely, even after the whole visible process tree has exited - matching exactly what both failing runs showed (process list at timeout had no \`executable.exe\`/\`bun.exe\`/\`cmd.exe\`/\`node.exe\` left, yet the read never completed).
- Fix (flowscripter/dynamic-plugin-framework#105): switch to \`"pipe"\` and forward output manually, so the leak can no longer reach the caller's handle.

## Test plan
- [x] \`bun test\` — pass
- [x] \`tsc --noEmit\` — clean
- [x] \`oxlint .\` — clean
- [x] Full \`functional_tests\` suite (\`behave\`) — 24 scenarios / 80 steps, all pass
- [ ] \`windows-latest\` CI — this is the platform the bug is specific to and I can't reproduce it locally (Linux); watching this PR's CI run to confirm

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SvxRNHoMxUCQwEcuvr8h7G