### PR TITLE
fix: bump dynamic-cli-framework to 5.1.8 to pick up install-spawn and registry-fetch timeout fixes

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,9 +5,9 @@
     "": {
       "name": "@flowscripter/example-cli",
       "dependencies": {
-        "@flowscripter/dynamic-cli-framework": "5.1.7",
+        "@flowscripter/dynamic-cli-framework": "5.1.8",
         "@flowscripter/dynamic-cli-framework-api": "^1.5.0",
-        "@flowscripter/dynamic-plugin-framework": "2.1.1",
+        "@flowscripter/dynamic-plugin-framework": "2.2.2",
       },
       "devDependencies": {
         "@types/bun": "^1.3.14",
@@ -21,11 +21,11 @@
     },
   },
   "packages": {
-    "@flowscripter/dynamic-cli-framework": ["@flowscripter/dynamic-cli-framework@5.1.7", "", { "dependencies": { "@flowscripter/dynamic-cli-framework-api": "^2.3.0", "@flowscripter/dynamic-plugin-framework": "^2.2.1", "emphasize": "^7.0.0", "fastest-levenshtein": "^1.0.16", "figlet": "^1.11.0", "highlight.js": "^11.11.1", "prettier": "^3.9.4", "semver": "^7.7.3", "supports-color": "^10.2.2", "supports-terminal-graphics": "^0.1.0" }, "peerDependencies": { "typescript": "^6.0.3" } }, "sha512-8KYZOv/hTR/Ex68oMrsUfqpIxTAlOWI/BHLe0VyThUwFSzoeBZ1myoFqzKH9JUPGM+BY75r6TinwlyD41iUU5g=="],
+    "@flowscripter/dynamic-cli-framework": ["@flowscripter/dynamic-cli-framework@5.1.8", "", { "dependencies": { "@flowscripter/dynamic-cli-framework-api": "^2.3.0", "@flowscripter/dynamic-plugin-framework": "^2.2.2", "emphasize": "^7.0.0", "fastest-levenshtein": "^1.0.16", "figlet": "^1.11.0", "highlight.js": "^11.11.1", "prettier": "^3.9.4", "semver": "^7.7.3", "supports-color": "^10.2.2", "supports-terminal-graphics": "^0.1.0" }, "peerDependencies": { "typescript": "^6.0.3" } }, "sha512-hdfY6maJK66PuCiXkvQcp6mbAKXWVSEQE8S4T061l1xVllc8iAMD0nSFvi05M5lg3lxvcewRIF/MTRgHrAHsPw=="],
 
     "@flowscripter/dynamic-cli-framework-api": ["@flowscripter/dynamic-cli-framework-api@1.5.0", "", { "peerDependencies": { "typescript": "^7.0.2" } }, "sha512-Tjs5rtaL7kEVZAdO2bM1vdbzCp5R5qGJxRFif6T1uilV5qQaVF92t1R90ndjSSb9G9KnyTDdhHe+NbpDOllvtA=="],
 
-    "@flowscripter/dynamic-plugin-framework": ["@flowscripter/dynamic-plugin-framework@2.1.1", "", { "dependencies": { "semver": "^7.8.5" }, "peerDependencies": { "typescript": "^7.0.2" } }, "sha512-0fHxgPAsb1xrnv3J8YdNtK0eOhTuKzM6J/fU4IYJEj5y8qlj7v1SZIO3+jvN3y8aEgYRxd6B2GAfXKk9WGR2Pg=="],
+    "@flowscripter/dynamic-plugin-framework": ["@flowscripter/dynamic-plugin-framework@2.2.2", "", { "dependencies": { "semver": "^7.8.5" }, "peerDependencies": { "typescript": "^7.0.2" } }, "sha512-S/YbHmfu3anV23jrAm+LefvnjLscyXvIpDwwyPjKJOpk8mcofedVMAYkF6JbZkeYNC7+i0Zvu3Zn/k0Wk5wNjQ=="],
 
     "@oxfmt/binding-android-arm-eabi": ["@oxfmt/binding-android-arm-eabi@0.56.0", "", { "os": "android", "cpu": "arm" }, "sha512-CSCxi7ovYojgfdPOdUb9T508HKeAdDIKeRGg7x8IZwVJrWz9gVgX7MbUnFqtQAE4QvoNo07mj2JlwnOzJw4qqA=="],
 
@@ -150,8 +150,6 @@
     "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
 
     "@flowscripter/dynamic-cli-framework/@flowscripter/dynamic-cli-framework-api": ["@flowscripter/dynamic-cli-framework-api@2.3.0", "", { "peerDependencies": { "typescript": "^7.0.2" } }, "sha512-L9seTKhhg08RcxSSCZOtDZKWYpHPyMQ2B3PqViqY9iFWitctsZqHjmFi636CEknM1CsXnzdNgSGsusg+pmDRJQ=="],
-
-    "@flowscripter/dynamic-cli-framework/@flowscripter/dynamic-plugin-framework": ["@flowscripter/dynamic-plugin-framework@2.2.1", "", { "dependencies": { "semver": "^7.8.5" }, "peerDependencies": { "typescript": "^7.0.2" } }, "sha512-/cODz4h3L4gbN8mTkv0GZQe6VHOOpc7y1ozB7tMk/C4PAZhVzSWxAA94H34+VzakUaYzB/z3pTkBzHT4i8sPjg=="],
 
     "emphasize/highlight.js": ["highlight.js@11.9.0", "", {}, "sha512-fJ7cW7fQGCYAkgv4CPfwFHrfd/cLS4Hau96JuJ+ZTOWhjnhoeN1ub1tFmALm/+lW5z4WCAuAV9bm05AP0mS6Gw=="],
 

--- a/package.json
+++ b/package.json
@@ -24,9 +24,9 @@
     "access": "public"
   },
   "dependencies": {
-    "@flowscripter/dynamic-cli-framework": "5.1.7",
+    "@flowscripter/dynamic-cli-framework": "5.1.8",
     "@flowscripter/dynamic-cli-framework-api": "^1.5.0",
-    "@flowscripter/dynamic-plugin-framework": "2.1.1"
+    "@flowscripter/dynamic-plugin-framework": "2.2.2"
   },
   "devDependencies": {
     "@types/bun": "^1.3.14",


### PR DESCRIPTION
## Summary
- Bumps `@flowscripter/dynamic-cli-framework` from 5.1.7 to 5.1.8 (dynamic-cli-framework#164), which wires `timeoutMs` through `SpawnInterfaceAdapter` and bumps `dynamic-plugin-framework` to 2.2.2 (registry-fetch timeout fix).
- Also bumps the direct `@flowscripter/dynamic-plugin-framework` pin in this repo from 2.1.1 to 2.2.2 to match, keeping the lockfile deduped to a single resolved version.
- These fixes target the windows-latest RELEASE workflow hang seen installing a plugin during the "Install example-cli-plugin" functional test scenario (a 60s Python subprocess timeout wrapper killed a hung `plugin:add` call). Root cause confirmed in job log: https://github.com/flowscripter/example-cli/actions/runs/30880854102/job/91901775175

Refs #147
Refs flowscripter/dynamic-cli-framework#148

## Test plan
- [x] `bun install` - lockfile updated, single deduped resolution of dynamic-plugin-framework@2.2.2
- [x] `bun test` - 5 pass
- [x] `tsc --noEmit` - no errors
- [x] `bunx oxlint index.ts src/ tests/` - clean
- [x] `bunx oxfmt --check .` - all files correctly formatted
- [x] `bun build index.ts --compile --outfile /tmp/example-cli` - builds
- [x] `behave` functional tests (ubuntu, local) - 4 features / 26 scenarios / 86 steps passed, including "Install example-cli-plugin" in well under the 60s timeout
- [ ] Release workflow `test-executable` jobs on windows-latest/macOS-latest/ubuntu-latest (post-merge only, not verifiable from this PR - see note below)

**Note:** The original hang was only ever reproduced in the RELEASE workflow's `call-release-bun-executable / test-executable` windows-latest job (run 30880854102), not in standard PR CI. This PR's CI cannot exercise that job. Once merged and released, the release workflow run should be watched specifically for the windows-latest "Install example-cli-plugin" scenario to confirm the hang is resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X1nPLbiXvGgZoKbkutfQvD