### PR TITLE
fix: bump dynamic-cli-framework to 5.3.3 and dynamic-cli-framework-api to 2.3.2

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,8 +5,8 @@
     "": {
       "name": "@flowscripter/example-cli",
       "dependencies": {
-        "@flowscripter/dynamic-cli-framework": "5.3.0",
-        "@flowscripter/dynamic-cli-framework-api": "^2.3.0",
+        "@flowscripter/dynamic-cli-framework": "5.3.3",
+        "@flowscripter/dynamic-cli-framework-api": "^2.3.2",
         "@flowscripter/dynamic-plugin-framework": "2.2.3",
       },
       "devDependencies": {
@@ -21,9 +21,9 @@
     },
   },
   "packages": {
-    "@flowscripter/dynamic-cli-framework": ["@flowscripter/dynamic-cli-framework@5.3.0", "", { "dependencies": { "@flowscripter/dynamic-cli-framework-api": "^2.3.0", "@flowscripter/dynamic-plugin-framework": "^2.2.3", "emphasize": "^7.0.0", "fastest-levenshtein": "^1.0.16", "figlet": "^1.11.0", "highlight.js": "^11.11.1", "prettier": "^3.9.4", "semver": "^7.7.3", "supports-color": "^10.2.2", "supports-terminal-graphics": "^0.1.0" }, "peerDependencies": { "typescript": "^6.0.3" } }, "sha512-3zdfIKs4jLTklOGmgp9iwHoF5E8eT8/AD3Wcme/QjAIR5L+5HQ1oGMOnYrVri/E4JUcpmXZJ3RIgTr8Ak6fwjQ=="],
+    "@flowscripter/dynamic-cli-framework": ["@flowscripter/dynamic-cli-framework@5.3.3", "", { "dependencies": { "@flowscripter/dynamic-cli-framework-api": "^2.3.0", "@flowscripter/dynamic-plugin-framework": "^2.2.3", "emphasize": "^7.0.0", "fastest-levenshtein": "^1.0.16", "figlet": "^1.11.0", "highlight.js": "^11.11.1", "prettier": "^3.9.4", "semver": "^7.7.3", "supports-color": "^10.2.2", "supports-terminal-graphics": "^0.1.0" }, "peerDependencies": { "typescript": "^6.0.3" } }, "sha512-f7tcXpg4I6V7Y65+nyQ3MriwgMDCsVs/UQuIcsgmqK2rvBp5BQ/aDyDX3sid197ubB7HERjvtUSyEOYFR28Zgw=="],
 
-    "@flowscripter/dynamic-cli-framework-api": ["@flowscripter/dynamic-cli-framework-api@2.3.0", "", { "peerDependencies": { "typescript": "^7.0.2" } }, "sha512-L9seTKhhg08RcxSSCZOtDZKWYpHPyMQ2B3PqViqY9iFWitctsZqHjmFi636CEknM1CsXnzdNgSGsusg+pmDRJQ=="],
+    "@flowscripter/dynamic-cli-framework-api": ["@flowscripter/dynamic-cli-framework-api@2.3.2", "", { "peerDependencies": { "typescript": "^7.0.2" } }, "sha512-N6icoIP5WBRt2EUF+PLWZr5iXAbAxa6QGkfBZNbxjJ5Z13+vUyTaTF6jEKGNv/9ekwTTmo0eBvOCqTNtFBi7zw=="],
 
     "@flowscripter/dynamic-plugin-framework": ["@flowscripter/dynamic-plugin-framework@2.2.3", "", { "dependencies": { "semver": "^7.8.5" }, "peerDependencies": { "typescript": "^7.0.2" } }, "sha512-vLoGC2LktUVPWqA66CwSzZtjh09zSR2HTuLa8OMGDumePkgZD0UTE9D2jWsd3bFdqcy14eQf3IYRdDM47+wRKg=="],
 

--- a/functional_tests/features/support/subprocess_wrapper.py
+++ b/functional_tests/features/support/subprocess_wrapper.py
@@ -1,27 +1,68 @@
 import platform
 import shlex
 import subprocess
+import threading
+import time
 import logging
 
 log = logging.getLogger("subprocess_wrapper")
 
 
-def _dump_process_tree():
-    # TEMPORARY: diagnosing an intermittent Windows-only hang in `plugin:add`. Dumps the OS
-    # process list on timeout so we can see whether a child npm/node process is stuck vs. our
-    # own process. Remove once root-caused.
+def _process_snapshot():
+    # TEMPORARY: diagnosing an intermittent Windows-only hang in `plugin:add`. `tasklist` alone
+    # doesn't show parent/child relationships or full command lines, so a renamed or wrapped
+    # process (e.g. a `cmd.exe /c bun.exe ...` shell hop) can't be distinguished from a process
+    # that never launched at all. Use PowerShell's Get-CimInstance for that detail on Windows.
     try:
         if platform.system() == 'Windows':
+            ps_cmd = (
+                "Get-CimInstance Win32_Process | "
+                "Select-Object ProcessId,ParentProcessId,Name,CommandLine | "
+                "Format-Table -AutoSize -Wrap | Out-String -Width 300"
+            )
             out = subprocess.run(
-                ['tasklist', '/v'], capture_output=True, text=True, timeout=10
+                ['powershell', '-NoProfile', '-Command', ps_cmd],
+                capture_output=True, text=True, timeout=10
             ).stdout
         else:
             out = subprocess.run(
                 ['ps', '-ef'], capture_output=True, text=True, timeout=10
             ).stdout
-        print('DEBUG: process list at timeout:\n{}'.format(out), flush=True)
+        return out
     except Exception as e:
-        print('DEBUG: failed to dump process list: {}'.format(e), flush=True)
+        return 'failed to snapshot process list: {}'.format(e)
+
+
+class _ProcessTreeMonitor:
+    # TEMPORARY: diagnosing an intermittent Windows-only hang in `plugin:add`. Polls the process
+    # tree every few seconds while a subprocess is running (rather than only once at timeout) so
+    # we can see whether the child process ever appears, and if so, whether it appears and then
+    # disappears before the outer timeout fires. Remove once root-caused.
+    def __init__(self, interval_seconds=5):
+        self.interval_seconds = interval_seconds
+        self._stop_event = threading.Event()
+        self._thread = None
+        self._start_time = None
+
+    def _run(self):
+        while not self._stop_event.wait(self.interval_seconds):
+            elapsed = time.monotonic() - self._start_time
+            snapshot = _process_snapshot()
+            print(
+                'DEBUG: process snapshot at +{:.1f}s:\n{}'.format(elapsed, snapshot),
+                flush=True,
+            )
+
+    def __enter__(self):
+        self._start_time = time.monotonic()
+        self._thread = threading.Thread(target=self._run, daemon=True)
+        self._thread.start()
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self._stop_event.set()
+        if self._thread is not None:
+            self._thread.join(timeout=self.interval_seconds + 5)
 
 
 class SubprocessWrapper:
@@ -39,15 +80,19 @@ class SubprocessWrapper:
         # hang in `plugin:add`. Remove once root-caused.
         print('DEBUG: running: {}'.format(cmd), flush=True)
         try:
-            result = subprocess.run(
-                cmd, capture_output=True, text=True, timeout=timeout, input=stdin_text,
-                encoding='utf-8', errors='replace'
-            )
+            with _ProcessTreeMonitor(interval_seconds=5):
+                result = subprocess.run(
+                    cmd, capture_output=True, text=True, timeout=timeout, input=stdin_text,
+                    encoding='utf-8', errors='replace'
+                )
         except subprocess.TimeoutExpired as e:
             print('DEBUG: TIMED OUT after {}s'.format(timeout), flush=True)
             print('DEBUG: partial stdout: {!r}'.format(e.stdout), flush=True)
             print('DEBUG: partial stderr: {!r}'.format(e.stderr), flush=True)
-            _dump_process_tree()
+            print(
+                'DEBUG: final process snapshot at timeout:\n{}'.format(_process_snapshot()),
+                flush=True,
+            )
             raise
         self.stdout = result.stdout
         self.stderr = result.stderr

--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@flowscripter/dynamic-cli-framework": "5.3.0",
-    "@flowscripter/dynamic-cli-framework-api": "^2.3.0",
+    "@flowscripter/dynamic-cli-framework": "5.3.3",
+    "@flowscripter/dynamic-cli-framework-api": "^2.3.2",
     "@flowscripter/dynamic-plugin-framework": "2.2.3"
   },
   "devDependencies": {


### PR DESCRIPTION
Refs #173
Refs flowscripter/dynamic-cli-framework#174

Picks up the corrected `PLUGIN_SERVICE_ID` value (flowscripter/dynamic-cli-framework#173) and the docs fix (flowscripter/dynamic-cli-framework#174) so both can be manually verified in a released example-cli version.

Also fixes a stale nested `dynamic-cli-framework-api` copy in bun.lock (5.3.0's dynamic-cli-framework subtree was still resolving 2.3.0 even after the top-level range was bumped) - required a clean node_modules/bun.lock reinstall rather than `bun update`, which only touched the top-level entry.