### PR TITLE
fix: bump dynamic-cli-framework to 5.4.0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "@flowscripter/example-cli",
       "dependencies": {
-        "@flowscripter/dynamic-cli-framework": "5.3.6",
+        "@flowscripter/dynamic-cli-framework": "5.4.0",
         "@flowscripter/dynamic-cli-framework-api": "^2.3.2",
         "@flowscripter/dynamic-plugin-framework": "2.2.4",
       },
@@ -21,7 +21,7 @@
     },
   },
   "packages": {
-    "@flowscripter/dynamic-cli-framework": ["@flowscripter/dynamic-cli-framework@5.3.6", "", { "dependencies": { "@flowscripter/dynamic-cli-framework-api": "^2.3.2", "@flowscripter/dynamic-plugin-framework": "^2.2.4", "emphasize": "^7.0.0", "fastest-levenshtein": "^1.0.16", "figlet": "^1.11.4", "highlight.js": "^11.12.0", "prettier": "^3.9.6", "semver": "^7.8.5", "supports-color": "^11.0.0", "supports-terminal-graphics": "^0.1.0" }, "peerDependencies": { "typescript": "^7.0.2" } }, "sha512-tyG+kEs/XQvumGBw83/G28162a6maJ2vdH3cEUKmE3MFX2xENBFZd6axzCjqI/nekhilvQtvzH1CbNj5zIpYFA=="],
+    "@flowscripter/dynamic-cli-framework": ["@flowscripter/dynamic-cli-framework@5.4.0", "", { "dependencies": { "@flowscripter/dynamic-cli-framework-api": "^2.3.2", "@flowscripter/dynamic-plugin-framework": "^2.2.4", "emphasize": "^7.0.0", "fastest-levenshtein": "^1.0.16", "figlet": "^1.11.4", "highlight.js": "^11.12.0", "prettier": "^3.9.6", "semver": "^7.8.5", "supports-color": "^11.0.0", "supports-terminal-graphics": "^0.1.0" }, "peerDependencies": { "typescript": "^7.0.2" } }, "sha512-C/ptYPjV1nXLkcjJ6gPe2T0oE19o27mSLLzB1y4+tZ4xFgDpq98mYsdorw0UR07OsgjQV1+60TUR7z3ZnpK9Nw=="],
 
     "@flowscripter/dynamic-cli-framework-api": ["@flowscripter/dynamic-cli-framework-api@2.3.2", "", { "peerDependencies": { "typescript": "^7.0.2" } }, "sha512-N6icoIP5WBRt2EUF+PLWZr5iXAbAxa6QGkfBZNbxjJ5Z13+vUyTaTF6jEKGNv/9ekwTTmo0eBvOCqTNtFBi7zw=="],
 

--- a/functional_tests/features/plugin.feature
+++ b/functional_tests/features/plugin.feature
@@ -24,11 +24,13 @@ Feature: Plugin management
     And the stderr should contain "Version 0.0.0-does-not-exist of plugin @flowscripter/example-cli-plugin was not found in the configured plugin registry"
 
   Scenario: Install example-cli-plugin
+    # dynamic-cli-framework 5.4.0+ shows "Searching for plugin: ..."/"Installing ..." via a
+    # spinner (PrinterService.showSpinner()), which is a documented no-op when stderr is not a
+    # TTY - so this non-interactive capture won't see that text in stderr. Only the final result
+    # message (printed via print(), not the spinner) is checked here.
     When the executable stdout is captured for "--no-prompt plugin:add @flowscripter/example-cli-plugin" with timeout 60s
     Then the captured process should complete with exit code 0
     And the stdout should contain "installed"
-    And the stderr should contain "Searching for plugin: @flowscripter/example-cli-plugin\n"
-    And the stderr should contain "Installing @flowscripter/example-cli-plugin"
 
   Scenario: Installing example-cli-plugin does not pull in the full dynamic-cli-framework
     Then the installed plugin dependencies should not include "figlet, emphasize, highlight.js, prettier, supports-color, supports-terminal-graphics"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@flowscripter/dynamic-cli-framework": "5.3.6",
+    "@flowscripter/dynamic-cli-framework": "5.4.0",
     "@flowscripter/dynamic-cli-framework-api": "^2.3.2",
     "@flowscripter/dynamic-plugin-framework": "2.2.4"
   },


### PR DESCRIPTION
Bumps @flowscripter/dynamic-cli-framework to 5.4.0, which includes the quote/mark upgrade spawn output, pre-spawn logging, and spinner UX from https://github.com/flowscripter/dynamic-cli-framework/pull/183 (Refs #181).

## Test plan
- [x] `bun install` clean reinstall, verified no stale nested dynamic-cli-framework-api copy
- [x] `bun test` (5/5 passing)